### PR TITLE
Update dependencies to fix Xcode 13 related issues

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,20 +3,20 @@
     "pins": [
       {
         "package": "AEXML",
-        "repositoryURL": "https://github.com/tadija/AEXML",
+        "repositoryURL": "https://github.com/tadija/AEXML.git",
         "state": {
           "branch": null,
-          "revision": "8623e73b193386909566a9ca20203e33a09af142",
-          "version": "4.5.0"
+          "revision": "38f7d00b23ecd891e1ee656fa6aeebd6ba04ecc3",
+          "version": "4.6.1"
         }
       },
       {
         "package": "PathKit",
-        "repositoryURL": "https://github.com/kylef/PathKit",
+        "repositoryURL": "https://github.com/kylef/PathKit.git",
         "state": {
           "branch": null,
-          "revision": "73f8e9dca9b7a3078cb79128217dc8f2e585a511",
-          "version": "1.0.0"
+          "revision": "3bfd2737b700b9a36565a8c94f4ad2b050a5e574",
+          "version": "1.0.1"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/kylef/Spectre.git",
         "state": {
           "branch": null,
-          "revision": "f79d4ecbf8bc4e1579fbd86c3e1d652fb6876c53",
-          "version": "0.9.2"
+          "revision": "26cc5e9ae0947092c7139ef7ba612e34646086c7",
+          "version": "0.10.1"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/tuist/XcodeProj.git",
         "state": {
           "branch": null,
-          "revision": "45e349e1c4e4da1a85a7b9392b737acde2e2f2a8",
-          "version": "7.23.0"
+          "revision": "64c4b956c1095dbba7a07107005342a25f1c5d6b",
+          "version": "8.5.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(url: "https://github.com/tuist/XcodeProj.git", .exact("8.0.0")),
+        .package(url: "https://github.com/tuist/XcodeProj.git", .exact("8.5.0")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
```
.../0431cedc0874173419d75c65db1e0674/external/com_github_revolut-mobile_xcodeprojFixUUIDs/.build/checkouts/PathKit/Sources/PathKit.swift:583:12: error: value of optional type 'UnsafeMutablePointer<CChar>?' (aka 'Optional<UnsafeMutablePointer<Int8>>') must be unwrapped to a value of type 'UnsafeMutablePointer<CChar>' (aka 'UnsafeMutablePointer<Int8>')
      free(cPattern)
           ^
```
Related issue in PathKit https://github.com/kylef/PathKit/issues/82 https://github.com/kylef/PathKit/pull/78